### PR TITLE
Template: Add Handbook Content Section

### DIFF
--- a/0000-template.md
+++ b/0000-template.md
@@ -60,7 +60,7 @@ documentation must be re-organized or altered?
 
 # Handbook Content
 
-Everything in this section should be _word-for-word_ what is proposed to go into the handbook - code examples, explanation of how WordPress Core may differ from usage of the feature etc. Keep it concise and readable.
+Everything in this section should be _word-for-word_ what is proposed to go into the handbook - code examples, explanation of how WordPress Core may differ from usage of the feature etc. Include a section title or what section of the handbook this should go into if it should be added to an existing section. Keep it concise and readable.
 
 # Unresolved questions
 

--- a/0000-template.md
+++ b/0000-template.md
@@ -58,6 +58,10 @@ idea best presented?
 Would the acceptance of this proposal mean the WordPress Coding Standards 
 documentation must be re-organized or altered? 
 
+# Handbook Content
+
+Everything in this section should be _word-for-word_ what is proposed to go into the handbook - code examples, explanation of how WordPress Core may differ from usage of the feature etc. Keep it concise and readable.
+
 # Unresolved questions
 
 Optional, but suggested for first drafts. What parts of the design are still


### PR DESCRIPTION
RFCs offer more detailed reasoning about the feature, aimed at the folks who will vote on it, than is necessary for the resulting Handbook content.

I think we can avoid ambiguity with _what_ would be presented to the rest of the WPCS consumers via the Handbook, by having a `Handbook Content` (or similarly named) section in the RFC.

This would then make it clear exactly what code snippets are to be presented to consumers, and the accompanying wording.